### PR TITLE
Fixed BMI classification based on WHO standards issue 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,12 +19,14 @@ function App() {
       let bmi = (weight / (height * height) * 703)
       setBmi(bmi.toFixed(1))
 
-      if (bmi < 25) {
-        setMessage('You are underweight')
+      if (bmi < 18.5) {
+        setMessage('You are underweight');
+      } else if (bmi >= 18.5 && bmi < 25) {
+        setMessage('You have a healthy weight');
       } else if (bmi >= 25 && bmi < 30) {
-        setMessage('You have healthy weight')
+        setMessage('You are overweight');
       } else {
-        setMessage('You are overweight')
+        setMessage('You are obese');
       }
     }
   }


### PR DESCRIPTION
### Fix BMI Calculation as per WHO Standards
Fixes #14 

This PR updates the BMI classification logic to align with WHO standards. Previously, the app classified BMI values incorrectly, where:

- BMI < 25 was labeled as underweight (incorrect).
- BMI 25-30 was considered a healthy weight (incorrect).
  
The corrected logic now follows the WHO classification:

1. BMI < 18.5 → Underweight
2. BMI 18.5 - 24.9 → Healthy weight
3. BMI 25 - 29.9 → Overweight
4. BMI ≥ 30 → Obese


