### PR TITLE
Add dark mode functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "lucide-react": "^0.485.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -11443,6 +11444,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.485.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.485.0.tgz",
+      "integrity": "sha512-NvyQJ0LKyyCxL23nPKESlr/jmz8r7fJO1bkuptSNYSy0s8VVj4ojhX0YAgmE1e0ewfxUZjIlZpvH+otfTnla8Q==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -24872,6 +24882,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lucide-react": {
+      "version": "0.485.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.485.0.tgz",
+      "integrity": "sha512-NvyQJ0LKyyCxL23nPKESlr/jmz8r7fJO1bkuptSNYSy0s8VVj4ojhX0YAgmE1e0ewfxUZjIlZpvH+otfTnla8Q==",
+      "requires": {}
     },
     "lz-string": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "lucide-react": "^0.485.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,71 @@
     transform: rotate(360deg);
   }
 }
+
+body {
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+body.dark-mode {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+.dark-mode .container {
+  background-color: #1e1e1e;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
+}
+
+.dark-mode input {
+  background-color: #2d2d2d;
+  color: #e0e0e0;
+  border: 1px solid #444;
+}
+
+.dark-mode .btn {
+  background-color: #3a3a3a;
+  color: #e0e0e0;
+}
+
+.dark-mode .btn-outline {
+  border: 1px solid #e0e0e0;
+  color: #e0e0e0;
+}
+
+.dark-mode-container {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 100;
+}
+
+.dark-mode-toggle .toggle-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f0f0f0;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  transition: all 0.3s ease;
+}
+
+.dark-mode-toggle .toggle-btn.dark {
+  background-color: #333;
+}
+
+.dark-mode-toggle .toggle-btn:hover {
+  transform: scale(1.1);
+}
+
+.dark-mode-toggle .toggle-btn svg {
+  color: #333;
+}
+
+.dark-mode-toggle .toggle-btn.dark svg {
+  color: #f0f0f0;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import './App.css';
 import './index.css'
 import React, {useState} from 'react'
+import DarkMode from './DarkMode';
 
 function App() {
   // state
@@ -40,6 +41,9 @@ function App() {
   
   return (
     <div className="app">
+    <div className="dark-mode-container">
+        <DarkMode /> {}
+      </div>
     <div className='container'>
       <h2 className='center'>BMI Calculator</h2>
         <form onSubmit={calcBmi}>

--- a/src/DarkMode.jsx
+++ b/src/DarkMode.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import { Moon, Sun } from 'lucide-react';
+
+const DarkMode = () => {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    
+    const savedDarkMode = localStorage.getItem('darkMode');
+    if (savedDarkMode === 'true') {
+      setIsDarkMode(true);
+      document.body.classList.add('dark-mode');
+    }
+  }, []);
+
+  const toggleDarkMode = () => {
+    const newDarkMode = !isDarkMode;
+    setIsDarkMode(newDarkMode);
+    
+    if (newDarkMode) {
+      document.body.classList.add('dark-mode');
+    } else {
+      document.body.classList.remove('dark-mode');
+    }
+    
+    
+    localStorage.setItem('darkMode', newDarkMode);
+  };
+
+  return (
+    <div className="dark-mode-toggle">
+      <button 
+        onClick={toggleDarkMode} 
+        className={`toggle-btn ${isDarkMode ? 'dark' : 'light'}`}
+        aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      >
+        {isDarkMode ? (
+          <Sun size={20} />
+        ) : (
+          <Moon size={20} />
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default DarkMode;


### PR DESCRIPTION
### **Add dark mode functionality**

- Created DarkMode.jsx component with toggle for light/dark themes
- Added dark mode toggle in top right corner of BMI calculator
- Implemented persistent theme selection using localStorage
- Added responsive styling for dark mode across all UI elements
- Enhanced accessibility with icon toggle and appropriate labels

This feature requires the Lucide React icon library. Please run **`npm install lucide-react`** before testing this PR to ensure the Sun/Moon icons display correctly in the dark mode toggle.


_Final Outputs Images_

![image](https://github.com/user-attachments/assets/6da399b0-b1a0-4185-b291-a3680918cb99)

![image](https://github.com/user-attachments/assets/094bdc60-1d32-4e10-b3ce-69f088633be4)
