### PR TITLE
Added feature to accept inputs in any units

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ function App() {
   const [height, setHeight] = useState(0)
   const [bmi, setBmi] = useState('')
   const [message, setMessage] = useState('')
+  const [unit, setUnit] = useState('imperial');
 
   let calcBmi = (event) => {
     event.preventDefault()
@@ -16,7 +17,12 @@ function App() {
     if (weight === 0 || height === 0) {
       alert('Please enter a valid weight and height')
     } else {
-      let bmi = (weight / (height * height) * 703)
+      let bmi;
+      if (unit === 'imperial') {
+        bmi = (weight / (height * height)) * 703; 
+      } else {
+        bmi = weight / (height * height); 
+      }
       setBmi(bmi.toFixed(1))
 
       

--- a/src/App.js
+++ b/src/App.js
@@ -48,14 +48,33 @@ function App() {
     <div className="app">
     <div className='container'>
       <h2 className='center'>BMI Calculator</h2>
+         {/* Unit Selection */}
+         <div className="unit-selector">
+          <label>Select Unit:</label>
+          <select value={unit} onChange={(e) => setUnit(e.target.value)}>
+            <option value="imperial">lbs & inches</option>
+            <option value="metric">kg & meters</option>
+          </select>
+        </div>
+
         <form onSubmit={calcBmi}>
           <div>
-            <label>Weight (lbs)</label>
-            <input type="text" placeholder='Enter Weight in lbs' value={weight} onChange={(e) => setWeight(e.target.value)} />
+            <label>Weight ({unit === 'imperial' ? 'lbs' : 'kg'})</label>
+            <input
+              type="text"
+              placeholder={`Enter weight in ${unit === 'imperial' ? 'lbs' : 'kg'}`}
+              value={weight}
+              onChange={(e) => setWeight(e.target.value)}
+            />
           </div>
           <div>
-            <label>Height (in)</label>
-            <input type="text" placeholder='Enter height in inches' value={height} onChange={(event) => setHeight(event.target.value)} />
+            <label>Height ({unit === 'imperial' ? 'in' : 'm'})</label>
+            <input
+              type="text"
+              placeholder={`Enter height in ${unit === 'imperial' ? 'inches' : 'meters'}`}
+              value={height}
+              onChange={(event) => setHeight(event.target.value)}
+            />
           </div>
           <div>
             <button className='btn' type='submit'>Submit</button>


### PR DESCRIPTION
I added a dropdown so users can choose between imperial (lbs & inches) and metric (kg & meters) units. The BMI calculation now adjusts based on the selected unit, using the correct formula for each. The input fields and labels update dynamically to match the chosen unit, making it easier for users to enter their measurements correctly. Now, the app correctly calculates BMI no matter which unit system is used.

![image](https://github.com/user-attachments/assets/3105283a-780e-4115-b5ce-39ff1bc75990)


Resolves #13 